### PR TITLE
Add the --verbose flag and request logging.

### DIFF
--- a/examples/server/CMakeLists.txt
+++ b/examples/server/CMakeLists.txt
@@ -1,6 +1,11 @@
 set(TARGET server)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_executable(${TARGET} server.cpp json.hpp httplib.h)
+target_compile_definitions(${TARGET} PRIVATE
+    $<$<CONFIG:Debug>:
+        CPPHTTPLIB_NO_EXCEPTIONS=1
+    >
+)
 target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_11)
 if(TARGET BUILD_INFO)


### PR DESCRIPTION
There's an exception handler too so the http 500 errors include the error description, if the executable is compiled in debug mode it crashes the server instead. I find that easier to debug.
I don't know if it prints too much stuff.