### PR TITLE
Replace invalid characters instead of crashing.

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -995,7 +995,8 @@ int main(int argc, char **argv)
           { "request", req.body },
           { "response", res.body },
       };
-      fprintf(stdout, "http_request: %s\n", log.dump().c_str());
+      fprintf(stdout, "http_request: %s\n",
+              log.dump(-1, ' ', false, json::error_handler_t::replace).c_str());
   });
 
   svr.set_exception_handler([](const Request &, Response &res, std::exception_ptr ep) {


### PR DESCRIPTION
@digiwombat 
It used to crash with a request like this while logging:
``` sh
echo -en "http://localhost:8080/test\xf0\xe0" | xargs curl
```